### PR TITLE
Fix hash value mismatch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,26 @@
+name: run-tests
+
+on:
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Install tox
+        run: pip install tox
+        shell: bash
+
+      - name: Run tests
+        run: tox
+        shell: bash

--- a/src/dva/api.py
+++ b/src/dva/api.py
@@ -1,4 +1,5 @@
 import os
+import re
 import hashlib
 from pyDataverse.api import NativeApi, DataAccessApi
 from pyDataverse.models import Datafile
@@ -18,13 +19,28 @@ class API(object):
         dataset = self._api.get_dataset(doi).json()
         return dataset['data']['latestVersion']['files']
 
-    def download_file(self, dvfile, path):
+    def _get_datafile_response(self, dvfile):
+        dv_data_file = dvfile["dataFile"]
+        # Retrieve the original file (that matches MD5 checksum) for files processed by Dataverse ingress
+        data_format = None
+        if dv_data_file.get("originalFileFormat"):
+            data_format = "original"
+
+        # NOTE: the call below blocks until the entire file is retrieved (in memory)
+        return self._data_api.get_datafile(dv_data_file["id"], data_format=data_format)
+
+    def download_file(self, dvfile, dest):
+        response = self._get_datafile_response(dvfile)
+        filename = self.get_download_filename(response)
+        directory_label = dvfile.get("directoryLabel", "")
+        if directory_label:
+            path = os.path.join(dest, directory_label, filename)
+        else:
+            path = os.path.join(dest, filename)
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        file_id = dvfile["dataFile"]["id"]
         with open(path, "wb") as f:
-            # NOTE: the call below blocks until the entire file is retrieved (in memory)
-            response = self._data_api.get_datafile(file_id)
             f.write(response.content)
+        return path
 
     @staticmethod
     def verify_checksum(dvfile, path):
@@ -51,19 +67,26 @@ class API(object):
            raise APIException(f"Uploading failed with status {status}.")
 
     @staticmethod
-    def get_dvfile_path(dvfile, parent_dir=None):
+    def get_remote_path(dvfile):
         path = dvfile["dataFile"]["filename"]
         directory_label = dvfile.get("directoryLabel", "")
         if directory_label:
             path = f"{directory_label}/{path}"
-        if parent_dir:
-            path = f"{parent_dir}/{path}"
         return path
+
+    @staticmethod
+    def get_download_filename(response):
+        content_disposition = response.headers['Content-disposition']
+        regex = '^ *filename=(.*?)$'
+        for part in content_disposition.split(';'):
+            found_items = re.findall(regex, part)
+            if found_items:
+                return found_items[0].strip('"')
+        raise APIException(f"Invalid Content-disposition {content_disposition}")
 
     @staticmethod
     def get_dvfile_size(dvfile):
         return dvfile["dataFile"]["filesize"]
-
 
 
 def get_api(url):

--- a/src/dva/cli.py
+++ b/src/dva/cli.py
@@ -27,8 +27,8 @@ def ls(doi, json_format, url):
         click.echo(json.dumps(dvfiles, indent=4))
     else:
         for dvfile in dvfiles:
-            path = api.get_dvfile_path(dvfile)
-            click.echo(path)
+            remote_path = api.get_remote_path(dvfile)
+            click.echo(remote_path)
 
 
 @click.command()
@@ -43,11 +43,12 @@ def download(doi, dest, url):
     """
     api = get_api(url)
     for dvfile in api.get_files_for_doi(doi):
-        path = api.get_dvfile_path(dvfile, dest)
-        click.echo(f"Downloading {path}")
-        api.download_file(dvfile, path)
+        file_id = dvfile["dataFile"]["id"]
+        click.echo(f"Downloading file {file_id}")
+        path = api.download_file(dvfile, dest)
+        click.echo(f"Downloaded file {file_id} to {path}")
         api.verify_checksum(dvfile, path)
-        click.echo(f"Verified file checksum for {path}.")
+        click.echo(f"Verified file checksum for {path}")
 
 
 @click.command()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py38
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Changes `dva` to download the file matching the checksum stored in Dataverse. For CSV and TSV files Dataverse defaults to downloading a reformatted TSV file. Downloaded filename is now based on content-disposition since the name stored in Dataverse is for the reformatted TSV file.

Adds github action config to run tests for PRs and pushes to main.

Fixes #6