### PR TITLE
Allow custom config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This command will prompt you for your Dataverse URL and API token and create a c
 with these two values in your home directory. The config file is named `.dataverse` and is in 
 JSON format containing keys "url" and "token".
 
+To use an alternate location for the config file set the `DATAVERSE_CONFIG_PATH` environment variable.
 
 ## Commands
 

--- a/src/dva/config.py
+++ b/src/dva/config.py
@@ -3,6 +3,7 @@ import json
 
 
 CONFIG_FILE = "~/.dataverse"
+CONFIG_FILE_PATH_VAR_NAME = "DATAVERSE_CONFIG_PATH"
 CONFIG_URL = "url"
 CONFIG_TOKEN = "token"
 
@@ -39,7 +40,9 @@ class Config(object):
 
 
 def _read_config_file():
-    path = os.path.expanduser(CONFIG_FILE)
+    path = os.environ.get(CONFIG_FILE_PATH_VAR_NAME)
+    if not path:
+        path = os.path.expanduser(CONFIG_FILE)
     if os.path.exists(path):
         with open(path, 'r') as infile:
             data = json.load(infile)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,8 +30,22 @@ class TestConfig(unittest.TestCase):
         })
         with patch("builtins.open", mock_open(read_data=config_file_data)) as mock_file:
             config = Config(url=None)
+        mock_file.assert_called_with(mock_os.path.expanduser.return_value, 'r')
         self.assertEqual(config.url, "myurl")
         self.assertEqual(config.token, "secret")
+
+    @patch('dva.config.os')
+    def test_config_from_file_with_env_setting(self, mock_os):
+        mock_os.path.exists.return_value = True # no config file
+        mock_os.path.exists.return_value = True # no config file
+        mock_os.environ = { "DATAVERSE_CONFIG_PATH" : "/tmp/.dataverse"}
+        config_file_data = json.dumps({
+            "url": "myurl",
+            "token": "secret",
+        })
+        with patch("builtins.open", mock_open(read_data=config_file_data)) as mock_file:
+            config = Config(url=None)
+        mock_file.assert_called_with('/tmp/.dataverse', 'r')
 
     @patch('dva.config.os')
     def test_config_env_variables(self, mock_os):


### PR DESCRIPTION
Adds optional DATAVERSE_CONFIG_PATH environment variable to set an alternate location for the dataverse config file.